### PR TITLE
Add WireMock modules for Golang and Python

### DIFF
--- a/modules/wiremock.md
+++ b/modules/wiremock.md
@@ -13,6 +13,44 @@ docs:
                 .withMapping("hello", WireMockContainerJunit5Test.class, "hello-world.json");
       wiremockServer.start();                
       ```
+  - id: golang
+    url: https://github.com/wiremock/wiremock-testcontainers-go
+    isThirdParty: true
+    example: |
+      ```golang
+        ctx := context.Background()
+        container, err := RunContainer(ctx,
+          WithImage("wiremock/wiremock:2.35.0-1"),
+          WithMappingFile("hello", filepath.Join("testdata", "hello-world.json")),
+        )
+        if err != nil {
+          t.Fatal(err)
+        }
+        t.Cleanup(func() {
+          if err := container.Terminate(ctx); err != nil {
+          t.Fatalf("failed to terminate container: %s", err)
+          }
+        })
+      ```
+  - id: python
+    url: https://wiremock.readthedocs.io/en/latest/testcontainers/
+    isThirdParty: true
+    example: |
+      ```python
+      @pytest.fixture(scope="session") # (1)
+      def wm_server():
+        with wiremock_container(secure=False) as wm:
+
+          Config.base_url = wm.get_url("__admin") # (2)
+          Mappings.create_mapping(
+            Mapping(
+              request=MappingRequest(method=HttpMethods.GET, url="/hello"),
+              response=MappingResponse(status=200, body="hello"),
+              persistent=False,
+            )
+          ) # (3)
+          yield wm
+      ```
 description: |
     This module allows provisioning the WireMock server as a standalone container within your tests,
     based on [WireMock Docker](https://github.com/wiremock/wiremock-docker).
@@ -21,6 +59,9 @@ description: |
     It can help you to create stable test and development environments,
     isolate yourself from flakey 3rd parties and simulate APIs that don’t exist yet.
     WireMock has a rich matching system, allowing any part of an incoming request
-    to be matched against complex and precise criteria. 
-    [Read more about WireMock](https://wiremock.org/docs/)
+    to be matched against complex and precise criteria.
+    
+    Read more: 
+     - [WireMock Documentation](https://wiremock.org/docs/)
+     - [WireMock and Testcontainers](https://wiremock.org/docs/solutions/testcontainers/)
 ---

--- a/modules/wiremock.md
+++ b/modules/wiremock.md
@@ -18,19 +18,19 @@ docs:
     isThirdParty: true
     example: |
       ```golang
-        ctx := context.Background()
-        container, err := RunContainer(ctx,
-          WithImage("wiremock/wiremock:2.35.0-1"),
-          WithMappingFile("hello", filepath.Join("testdata", "hello-world.json")),
-        )
-        if err != nil {
-          t.Fatal(err)
-        }
-        t.Cleanup(func() {
-          if err := container.Terminate(ctx); err != nil {
-          t.Fatalf("failed to terminate container: %s", err)
-          }
-        })
+       ctx := context.Background()
+       container, err := RunContainer(ctx,
+         WithImage("wiremock/wiremock:2.35.0-1"),
+         WithMappingFile("hello", filepath.Join("testdata", "hello-world.json")),
+       )
+       if err != nil {
+         t.Fatal(err)
+       }
+       t.Cleanup(func() {
+         if err := container.Terminate(ctx); err != nil {
+         t.Fatalf("failed to terminate container: %s", err)
+         }
+       })
       ```
   - id: python
     url: https://wiremock.readthedocs.io/en/latest/testcontainers/

--- a/modules/wiremock.md
+++ b/modules/wiremock.md
@@ -13,7 +13,7 @@ docs:
                 .withMapping("hello", WireMockContainerJunit5Test.class, "hello-world.json");
       wiremockServer.start();                
       ```
-  - id: golang
+  - id: go
     url: https://github.com/wiremock/wiremock-testcontainers-go
     isThirdParty: true
     example: |


### PR DESCRIPTION
Adds entries for Golang and Python

Also, a summary page on the WireMock side: https://github.com/wiremock/wiremock.org/pull/129