### PR TITLE
Update Microcks version to release

### DIFF
--- a/modules/microcks.md
+++ b/modules/microcks.md
@@ -8,7 +8,7 @@ docs:
     url: https://github.com/microcks/microcks-testcontainers-java
     example: |
       ```java
-      var microcks = new MicrocksContainer(DockerImageName.parse("quay.io/microcks/microcks-uber:nightly"));
+      var microcks = new MicrocksContainer(DockerImageName.parse("quay.io/microcks/microcks-uber:1.8.0"));
       microcks.start();
       ```
   - id: nodejs


### PR DESCRIPTION
Now that `microcks-uber` image has been released, we can move from the `nightly` version to this release.
Signed-off-by: Laurent Broudoux <laurent.broudoux@gmail.com>