### PR TITLE
chore: add openfga-go

### DIFF
--- a/modules/openfga.md
+++ b/modules/openfga.md
@@ -10,6 +10,12 @@ docs:
       var openfga = new OpenFGAContainer("openfga/openfga:v1.4.3");
       openfga.start();
       ```
+  - id: go
+    url: https://golang.testcontainers.org/modules/openfga/
+    example: |
+      ```go
+      openfgaContainer, err := openfga.RunContainer(ctx, testcontainers.WithImage("openfga/openfga:v1.5.0"))
+      ```
 description: |
   OpenFGA is an open-source authorization solution that allows developers to build granular access control using an easy-to-read modeling language and friendly APIs.
 ---


### PR DESCRIPTION
Adds the testcontainers-go module for OpenFGA

https://golang.testcontainers.org/modules/openfga/
