### PR TITLE
chore: add aerospike to vector databases category

### DIFF
--- a/modules/aerospike/index.md
+++ b/modules/aerospike/index.md
@@ -2,6 +2,7 @@
 title: Aerospike
 categories:
   - nosql-database
+  - vector-database
 docs:
   - id: go
     url: https://github.com/ajeetdsouza/testcontainers-aerospike-go


### PR DESCRIPTION
In the light of https://twitter.com/aHev/status/1776346861793931376