### PR TITLE
docs: update modules API for tc-go

### DIFF
--- a/modules/artemis/index.md
+++ b/modules/artemis/index.md
@@ -16,7 +16,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      artemisContainer, err := artemis.RunContainer(ctx, testcontainers.WithImage("docker.io/apache/activemq-artemis:2.30.0-alpine"))
+      artemisContainer, err := artemis.Run(ctx, "docker.io/apache/activemq-artemis:2.30.0-alpine")
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.ActiveMQ

--- a/modules/azurite/index.md
+++ b/modules/azurite/index.md
@@ -3,6 +3,13 @@ title: Azurite
 categories:
   - cloud
 docs:
+  - id: go
+    url: https://golang.testcontainers.org/modules/azurite/
+    maintainer: core
+    example: |
+      ```go
+      azuriteContainer, err := azurite.Run(ctx, "mcr.microsoft.com/azure-storage/azurite:3.28.0")
+      ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.Azurite
     maintainer: core

--- a/modules/cassandra/index.md
+++ b/modules/cassandra/index.md
@@ -16,7 +16,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      cassandraContainer, err := cassandra.RunContainer(ctx, testcontainers.WithImage("cassandra:4.1.3"))
+      cassandraContainer, err := cassandra.Run(ctx, "cassandra:4.1.3")
       ```
 description: |
   Cassandra is a free and open source, distributed NoSQL database management system. It is designed to handle large amounts of data across many commodity servers, providing high availability with no single point of failure.

--- a/modules/chroma/index.md
+++ b/modules/chroma/index.md
@@ -15,7 +15,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      chromaContainer, err := chroma.RunContainer(ctx, testcontainers.WithImage("chromadb/chroma:0.4.22"))
+      chromaContainer, err := chroma.Run(ctx, "chromadb/chroma:0.4.22")
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/chromadb/

--- a/modules/clickhouse/index.md
+++ b/modules/clickhouse/index.md
@@ -16,7 +16,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      clickHouseContainer, err := clickhouse.RunContainer(ctx, testcontainers.WithImage("clickhouse/clickhouse-server:23.3.8.21-alpine"))
+      clickHouseContainer, err := clickhouse.Run(ctx, "clickhouse/clickhouse-server:23.3.8.21-alpine")
       ```
 description: |
   ClickHouse is an open-source database management system for analytical processing that allows users to generate reports using SQL queries in real-time.

--- a/modules/cockroachdb/index.md
+++ b/modules/cockroachdb/index.md
@@ -19,7 +19,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      cockroachdbContainer, err := cockroachdb.RunContainer(ctx, testcontainers.WithImage("cockroachdb/cockroach:v22.2.3")
+      cockroachdbContainer, err := cockroachdb.Run(ctx, "cockroachdb/cockroach:v22.2.3")
       ```
 description: |
   CockroachDB is an open-source, cloud-native, resilient, distributed SQL database.

--- a/modules/consul/index.md
+++ b/modules/consul/index.md
@@ -16,7 +16,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      consulContainer, err := consul.RunContainer(ctx, testcontainers.WithImage("hashicorp/consul:1.15"))
+      consulContainer, err := consul.Run(ctx, "hashicorp/consul:1.15")
       ```
 description: |
   Consul is a service mesh and distributed key-value store.

--- a/modules/couchbase/index.md
+++ b/modules/couchbase/index.md
@@ -18,8 +18,8 @@ docs:
     maintainer: core
     example: |
       ```go
-      couchbaseContainer, err := couchbase.RunContainer(ctx,
-        testcontainers.WithImage("couchbase/server:community-7.0.2"),
+      couchbaseContainer, err := couchbase.Run(ctx,
+        "couchbase/server:community-7.0.2",
         couchbase.WithBucket(couchbase.NewBucket("bucketName")),
       )
       ```

--- a/modules/dolt/index.md
+++ b/modules/dolt/index.md
@@ -8,7 +8,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      doltContainer, err := dolt.RunContainer(ctx, testcontainers.WithImage("dolthub/dolt-sql-server:1.32.4"))
+      doltContainer, err := dolt.Run(ctx, "dolthub/dolt-sql-server:1.32.4")
       ```
 description: |
   Dolt is a SQL database that you can fork, clone, branch, merge, push and pull just like a Git repository.

--- a/modules/elasticsearch/index.md
+++ b/modules/elasticsearch/index.md
@@ -17,7 +17,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      elasticsearchContainer, err := elasticsearch.RunContainer(ctx, testcontainers.WithImage("docker.elastic.co/elasticsearch/elasticsearch:8.9.0"))
+      elasticsearchContainer, err := elasticsearch.Run(ctx, "docker.elastic.co/elasticsearch/elasticsearch:8.9.0")
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.Elasticsearch

--- a/modules/inbucket/index.md
+++ b/modules/inbucket/index.md
@@ -8,7 +8,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      inbucketContainer, err := inbucket.RunContainer(ctx, testcontainers.WithImage("inbucket/inbucket:sha-2d409bb"))
+      inbucketContainer, err := inbucket.Run(ctx, "inbucket/inbucket:sha-2d409bb")
       ```
 description: |
   Inbucket is an email testing application; it will accept messages for any email address and make them available to view via a web interface.

--- a/modules/influxdb/index.md
+++ b/modules/influxdb/index.md
@@ -16,7 +16,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      influxdbContainer, err := influxdb.RunContainer(ctx, testcontainers.WithImage("influxdb:1.8.10"))
+      influxdbContainer, err := influxdb.Run(ctx, "influxdb:1.8.10")
       ```
 description: |
   InfluxDB is an open-source time series database for storage and retrieval of time series data in fields such as operations monitoring, application metrics, Internet of Things sensor data, and real-time analytics.

--- a/modules/k3s/index.md
+++ b/modules/k3s/index.md
@@ -16,7 +16,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      k3sContainer, err := k3s.RunContainer(ctx, testcontainers.WithImage("rancher/k3s:v1.27.1-k3s1"))
+      k3sContainer, err := k3s.Run(ctx, "rancher/k3s:v1.27.1-k3s1")
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.K3s

--- a/modules/k6/index.md
+++ b/modules/k6/index.md
@@ -15,7 +15,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      k6Container, err := k6.RunContainer(ctx, testcontainers.WithImage("szkiba/k6x:v0.3.1"))
+      k6Container, err := k6.Run(ctx, "szkiba/k6x:v0.3.1")
       ```
 description: |
   k6 is an open-source tool and cloud service that makes load testing easy for developers and QA engineers.

--- a/modules/kafka/index.md
+++ b/modules/kafka/index.md
@@ -16,7 +16,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      kafkaContainer, err := kafka.RunContainer(ctx, testcontainers.WithImage("confluentinc/confluent-local:7.5.0"))
+      kafkaContainer, err := kafka.Run(ctx, "confluentinc/confluent-local:7.5.0")
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.Kafka

--- a/modules/localstack/index.md
+++ b/modules/localstack/index.md
@@ -19,7 +19,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      localstackContainer, err := localstack.RunContainer(ctx, testcontainers.WithImage("localstack/localstack:1.4.0"))
+      localstackContainer, err := localstack.Run(ctx, "localstack/localstack:1.4.0")
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.LocalStack

--- a/modules/mariadb/index.md
+++ b/modules/mariadb/index.md
@@ -16,7 +16,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      mariaDBContainer, err := mariadb.RunContainer(ctx, testcontainers.WithImage("mariadb:11.0.3"))
+      mariaDBContainer, err := mariadb.Run(ctx, "mariadb:11.0.3")
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.MariaDb

--- a/modules/milvus/index.md
+++ b/modules/milvus/index.md
@@ -15,7 +15,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      milvusContainer, err := milvus.RunContainer(ctx, testcontainers.WithImage("milvusdb/milvus:v2.3.9"))
+      milvusContainer, err := milvus.Run(ctx, "milvusdb/milvus:v2.3.9")
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.Milvus

--- a/modules/minio/index.md
+++ b/modules/minio/index.md
@@ -16,7 +16,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      minioContainer, err := minio.RunContainer(ctx, testcontainers.WithImage("minio/minio:RELEASE.2024-01-16T16-07-38Z"))
+      minioContainer, err := minio.Run(ctx, "minio/minio:RELEASE.2024-01-16T16-07-38Z")
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.Minio

--- a/modules/mockserve/index.md
+++ b/modules/mockserve/index.md
@@ -17,7 +17,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      mockServerContainer, err := mockserver.RunContainer(ctx, testcontainers.WithImage("mockserver/mockserver:5.15.0"))
+      mockServerContainer, err := mockserver.Run(ctx, "mockserver/mockserver:5.15.0")
       ```
 description: |
   MockServer allows you to mock any server or service via HTTP or HTTPS, such as a REST or RPC service.

--- a/modules/mongodb/index.md
+++ b/modules/mongodb/index.md
@@ -16,7 +16,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      mongoDBContainer, err := mongodb.RunContainer(ctx, testcontainers.WithImage("mongo:6"))
+      mongoDBContainer, err := mongodb.Run(ctx, "mongo:6")
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.MongoDb

--- a/modules/mssql/index.md
+++ b/modules/mssql/index.md
@@ -17,8 +17,8 @@ docs:
     maintainer: core
     example: |
       ```go
-      mssqlContainer, err := mssql.RunContainer(ctx,
-        testcontainers.WithImage("mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04"),
+      mssqlContainer, err := mssql.Run(ctx,
+        "mcr.microsoft.com/mssql/server:2022-CU10-ubuntu-22.04",
         mssql.WithAcceptEULA(),
       )
       ```

--- a/modules/mysql/index.md
+++ b/modules/mysql/index.md
@@ -16,7 +16,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      mysqlContainer, err := mysql.RunContainer(ctx, testcontainers.WithImage("mysql:5.7.34"))
+      mysqlContainer, err := mysql.Run(ctx, "mysql:5.7.34")
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.MySql

--- a/modules/nats/index.md
+++ b/modules/nats/index.md
@@ -8,7 +8,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      natsContainer, err := nats.RunContainer(ctx, testcontainers.WithImage("nats:2.9"))
+      natsContainer, err := nats.Run(ctx, "nats:2.9")
       ``````
   - id: nodejs
     url: https://node.testcontainers.org/modules/nats/

--- a/modules/neo4j/index.md
+++ b/modules/neo4j/index.md
@@ -20,8 +20,8 @@ docs:
     maintainer: core
     example: |
       ```go
-      neo4jContainer, err := neo4j.RunContainer(ctx,
-        testcontainers.WithImage("neo4j:4.4"),
+      neo4jContainer, err := neo4j.Run(ctx,
+        "neo4j:4.4",
         neo4j.WithAdminPassword("letmein!"),
         neo4j.WithLabsPlugin(neo4j.Apoc),
       )

--- a/modules/ollama/index.md
+++ b/modules/ollama/index.md
@@ -17,8 +17,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      ollamaContainer, err := ollama.RunContainer(ctx,
-              testcontainers.WithImage("ollama/ollama:0.1.26"))
+      ollamaContainer, err := ollama.Run(ctx, "ollama/ollama:0.1.26")
       if err != nil {
             log.Fatalf("failed to start container: %s", err)
       }

--- a/modules/openfga/index.md
+++ b/modules/openfga/index.md
@@ -16,7 +16,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      openfgaContainer, err := openfga.RunContainer(ctx, testcontainers.WithImage("openfga/openfga:v1.5.0"))
+      openfgaContainer, err := openfga.Run(ctx, "openfga/openfga:v1.5.0")
       ```
 description: |
   OpenFGA is an open-source authorization solution that allows developers to build granular access control using an easy-to-read modeling language and friendly APIs.

--- a/modules/openldap/index.md
+++ b/modules/openldap/index.md
@@ -8,7 +8,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      openldapContainer, err := openldap.RunContainer(ctx, testcontainers.WithImage("bitnami/openldap:2.6.6"))
+      openldapContainer, err := openldap.Run(ctx, "bitnami/openldap:2.6.6")
       ```
 description: |
   OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol (LDAP).

--- a/modules/opensearch/index.md
+++ b/modules/opensearch/index.md
@@ -17,7 +17,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      opensearchContainer, err := opensearch.RunContainer(ctx, testcontainers.WithImage("opensearchproject/opensearch:2.11.1"))
+      opensearchContainer, err := opensearch.Run(ctx, "opensearchproject/opensearch:2.11.1")
       ```
 description: |
   OpenSearch is a scalable, flexible, and extensible open-source software suite for search, analytics, and observability applications licensed under Apache 2.0 and powered by Apache Lucene.

--- a/modules/pgvector/index.md
+++ b/modules/pgvector/index.md
@@ -18,8 +18,8 @@ docs:
     maintainer: core
     example: |
       ```go
-      pgVectorContainer, err := postgres.RunContainer(ctx,
-        testcontainers.WithImage("pgvector/pgvector:pg16"),
+      pgVectorContainer, err := postgres.Run(ctx,
+        "pgvector/pgvector:pg16",
         postgres.WithDatabase("test"),
         postgres.WithUsername("user"),
         postgres.WithPassword("password"),

--- a/modules/postgis/index.md
+++ b/modules/postgis/index.md
@@ -18,8 +18,8 @@ docs:
     maintainer: core
     example: |
       ```go
-      postgisContainer, err := postgres.RunContainer(ctx,
-        testcontainers.WithImage("postgis/postgis:12-3.0"),
+      postgisContainer, err := postgres.Run(ctx,
+        "postgis/postgis:12-3.0",
         postgres.WithDatabase("test"),
         postgres.WithUsername("user"),
         postgres.WithPassword("password"),

--- a/modules/postgresql/index.md
+++ b/modules/postgresql/index.md
@@ -17,8 +17,8 @@ docs:
     maintainer: core
     example: |
       ```go
-      postgresContainer, err := postgres.RunContainer(ctx,
-        testcontainers.WithImage("postgres:16-alpine"),
+      postgresContainer, err := postgres.Run(ctx,
+        "postgres:16-alpine",
         postgres.WithDatabase("test"),
         postgres.WithUsername("user"),
         postgres.WithPassword("password"),

--- a/modules/pulsar/index.md
+++ b/modules/pulsar/index.md
@@ -19,8 +19,8 @@ docs:
     maintainer: official
     example: |
       ```go
-      pulsarContainer, err := pulsar.RunContainer(ctx,
-        testcontainers.WithImage("apachepulsar/pulsar:2.10.0"),
+      pulsarContainer, err := pulsar.Run(ctx,
+        "apachepulsar/pulsar:2.10.0",
         pulsar.WithPulsarEnv("brokerDeduplicationEnabled", "true"),
         pulsar.WithFunctionsWorker(),
         pulsar.WithTransactions(),

--- a/modules/qdrant/index.md
+++ b/modules/qdrant/index.md
@@ -18,7 +18,7 @@ docs:
     maintainer: official
     example: |
       ```go
-      qdrantContainer, err := qdrant.RunContainer(ctx, testcontainers.WithImage("qdrant/qdrant:v1.7.4"))
+      qdrantContainer, err := qdrant.Run(ctx, "qdrant/qdrant:v1.7.4")
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/qdrant/

--- a/modules/rabbitmq/index.md
+++ b/modules/rabbitmq/index.md
@@ -16,7 +16,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      rabbitmqContainer, err := rabbitmq.RunContainer(ctx, testcontainers.WithImage("rabbitmq:3.7.25-management-alpine"),
+      rabbitmqContainer, err := rabbitmq.Run(ctx, "rabbitmq:3.7.25-management-alpine")
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.RabbitMq

--- a/modules/redis/index.md
+++ b/modules/redis/index.md
@@ -17,7 +17,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      redisContainer, err := redis.RunContainer(ctx, testcontainers.WithImage("redis:6"))
+      redisContainer, err := redis.Run(ctx, "redis:6")
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.Redis

--- a/modules/redpanda/index.md
+++ b/modules/redpanda/index.md
@@ -19,7 +19,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      redpandaContainer, err := redpanda.RunContainer(ctx, testcontainers.WithImage("docker.redpanda.com/redpandadata/redpanda:v23.1.7"))
+      redpandaContainer, err := redpanda.Run(ctx, "docker.redpanda.com/redpandadata/redpanda:v23.1.7")
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.Redpanda

--- a/modules/spicedb/index.md
+++ b/modules/spicedb/index.md
@@ -8,7 +8,7 @@ docs:
     maintainer: community
     example: |
       ```go
-        spiceDBContainer, err := spicedb.RunContainer(ctx, testcontainers.WithImage("authzed/spicedb:v1.33.0"))
+        spiceDBContainer, err := spicedb.Run(ctx, "authzed/spicedb:v1.33.0")
       ```
 description: |
   SpiceDB is a graph database purpose-built for storing and evaluating access control data.

--- a/modules/surrealdb/index.md
+++ b/modules/surrealdb/index.md
@@ -8,7 +8,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      surrealdbContainer, err := surrealdb.RunContainer(ctx, testcontainers.WithImage("surrealdb/surrealdb:v1.1.1"))
+      surrealdbContainer, err := surrealdb.Run(ctx, "surrealdb/surrealdb:v1.1.1")
       ```
   - id: rust
     url: https://github.com/testcontainers/testcontainers-rs-modules-community

--- a/modules/timescale/index.md
+++ b/modules/timescale/index.md
@@ -18,8 +18,8 @@ docs:
     maintainer: core
     example: |
       ```go
-      timescaleContainer, err := postgres.RunContainer(ctx,
-        testcontainers.WithImage("timescale/timescaledb:2.1.0-pg11"),
+      timescaleContainer, err := postgres.Run(ctx,
+        "timescale/timescaledb:2.1.0-pg11",
         postgres.WithDatabase("test"),
         postgres.WithUsername("user"),
         postgres.WithPassword("password"),

--- a/modules/vault/index.md
+++ b/modules/vault/index.md
@@ -16,8 +16,8 @@ docs:
     maintainer: core
     example: |
       ```go
-      vaultContainer, err := vault.RunContainer(ctx,
-        testcontainers.WithImage("hashicorp/vault:1.13.0"),
+      vaultContainer, err := vault.Run(ctx,
+        "hashicorp/vault:1.13.0",
         vault.WithToken("root-token"),
         vault.WithInitCommand("secrets enable transit", "write -f transit/keys/my-key"),
         vault.WithInitCommand("kv put secret/test1 foo1=bar1"),

--- a/modules/vearch/index.md
+++ b/modules/vearch/index.md
@@ -8,7 +8,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      vearchContainer, err := vearch.RunContainer(ctx, testcontainers.WithImage("vearch/vearch:3.5.1"))
+      vearchContainer, err := vearch.Run(ctx, "vearch/vearch:3.5.1")
       ```
 description: |
   Vearch is a cloud-native distributed vector database for efficient similarity search of embedding vectors in your AI applications.

--- a/modules/weaviate/index.md
+++ b/modules/weaviate/index.md
@@ -18,7 +18,7 @@ docs:
     maintainer: core
     example: |
       ```go
-      weaviateContainer, err := weaviate.RunContainer(ctx, testcontainers.WithImage("semitechnologies/weaviate:1.23.9"))
+      weaviateContainer, err := weaviate.Run(ctx, "semitechnologies/weaviate:1.23.9")
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/weaviate/


### PR DESCRIPTION
Update all tc-go modules using the new API, which are all of them hosted in the testcontainers-go repo.

All community modules have not been updated, so it's up to the maintainers to come and update them when the module receives the new API changes.
