### PR TITLE
feat: add community module for permify service

### DIFF
--- a/modules/permify/index.md
+++ b/modules/permify/index.md
@@ -1,0 +1,22 @@
+---
+title: Permify
+categories:
+ - other
+docs:
+ - id: go
+   url: https://github.com/theoriginalstove/testcontainers-permify
+   maintainer: community
+   example: |
+       ```go
+       container, err := permifytest.Run(ctx)
+       if err != nil {
+           return err
+       }
+       ```
+   installation: |
+       ```bash
+       go get -u github.com/theoriginalstove/testcontainers-permify
+       ```
+---
+
+

--- a/modules/permify/index.md
+++ b/modules/permify/index.md
@@ -17,6 +17,8 @@ docs:
        ```bash
        go get -u github.com/theoriginalstove/testcontainers-permify
        ```
+description: |
+    Permify is an open-source authorization service for creating fine-grained and scalable authorization systems.
 ---
 
 


### PR DESCRIPTION
Wanted to create a community module for Permify since I also wanted to use testcontainers within my own go code and saw this issue on the Permify repo: https://github.com/Permify/permify/issues/1304