### PR TITLE
chore: use testcontainers's core for DynamoDB

### DIFF
--- a/modules/dynamodb/index.md
+++ b/modules/dynamodb/index.md
@@ -4,15 +4,15 @@ categories:
   - nosql-database
 docs:
   - id: go
-    url: https://github.com/abhirockzz/dynamodb-local-testcontainers-go
-    maintainer: community
+    url: https://golang.testcontainers.org/modules/dynamodb/
+    maintainer: core
     example: |
       ```go
-      dynamodbLocalContainer, err := dynamodblocal.RunContainer(context.Background(), testcontainers.WithImage("amazon/dynamodb-local:2.2.1"))
+      dynamodbContainer, err := dynamodblocal.Run(context.Background(), "amazon/dynamodb-local:2.2.1")
       ```
     installation: |
       ```bash
-      go get github.com/abhirockzz/dynamodb-local-testcontainers-go
+      go get github.com/testcontainers/testcontainers-go/modules/dynamodb
       ```
   - id: dotnet
     url: https://www.nuget.org/packages/Testcontainers.DynamoDb


### PR DESCRIPTION
It replaces the community module with the core one, as it seems the community module is not receiving the updates the community is asking for.
