### PR TITLE
feat: Add missing .NET modules

### DIFF
--- a/modules/arangodb/index.md
+++ b/modules/arangodb/index.md
@@ -32,7 +32,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.ArangoDb --version 3.9.0
+      dotnet add package Testcontainers.ArangoDb
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/arangodb/

--- a/modules/artemis/index.md
+++ b/modules/artemis/index.md
@@ -43,7 +43,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.ActiveMq --version 3.9.0
+      dotnet add package Testcontainers.ActiveMq
       ```
 description: |
   Apache ActiveMQ Artemis is an open source project to build a multi-protocol, embeddable, very high performance, clustered, asynchronous messaging system.

--- a/modules/azurite/index.md
+++ b/modules/azurite/index.md
@@ -26,7 +26,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.Azurite --version 3.9.0
+      dotnet add package Testcontainers.Azurite
       ```
   - id: python
     url: https://testcontainers-python.readthedocs.io/en/latest/modules/azurite/README.html

--- a/modules/clickhouse/index.md
+++ b/modules/clickhouse/index.md
@@ -31,6 +31,20 @@ docs:
       ```bash
       go get github.com/testcontainers/testcontainers-go/modules/clickhouse
       ```
+  - id: dotnet
+    url: https://www.nuget.org/packages/Testcontainers.ClickHouse
+    maintainer: core
+    example: |
+      ```csharp
+      var clickHouseContainer = new ClickHouseBuilder()
+        .WithImage("clickhouse/clickhouse-server:23.6-alpine")
+        .Build();
+      await clickHouseContainer.StartAsync();
+      ```
+    installation: |
+      ```bash
+      dotnet add package Testcontainers.ClickHouse
+      ```
   - id: python
     url: https://testcontainers-python.readthedocs.io/en/latest/modules/clickhouse/README.html
     maintainer: core

--- a/modules/cockroachdb/index.md
+++ b/modules/cockroachdb/index.md
@@ -34,6 +34,20 @@ docs:
       ```bash
       go get github.com/testcontainers/testcontainers-go/modules/cockroachdb
       ```
+  - id: dotnet
+    url: https://www.nuget.org/packages/Testcontainers.CockroachDb
+    maintainer: core
+    example: |
+      ```csharp
+      var cockroachDbContainer = new CockroachDbBuilder()
+        .WithImage("cockroachdb/cockroach:latest-v23.1")
+        .Build();
+      await cockroachDbContainer.StartAsync();
+      ```
+    installation: |
+      ```bash
+      dotnet add package Testcontainers.CockroachDb
+      ```
   - id: python
     url: https://testcontainers-python.readthedocs.io/en/latest/modules/cockroachdb/README.html
     maintainer: core

--- a/modules/consul/index.md
+++ b/modules/consul/index.md
@@ -31,6 +31,20 @@ docs:
       ```bash
       go get github.com/testcontainers/testcontainers-go/modules/consul
       ```
+  - id: dotnet
+    url: https://www.nuget.org/packages/Testcontainers.Consul
+    maintainer: core
+    example: |
+      ```csharp
+      var consulContainer = new ConsulBuilder()
+        .WithImage("consul:1.15")
+        .Build();
+      await consulContainer.StartAsync();
+      ```
+    installation: |
+      ```bash
+      dotnet add package Testcontainers.Consul
+      ```
 description: |
   Consul is a service mesh and distributed key-value store.
 

--- a/modules/cosmodb/index.md
+++ b/modules/cosmodb/index.md
@@ -34,7 +34,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.CosmosDb --version 3.9.0
+      dotnet add package Testcontainers.CosmosDb
       ```
   - id: python
     url: https://testcontainers-python.readthedocs.io/en/latest/modules/cosmosdb/README.html

--- a/modules/couchbase/index.md
+++ b/modules/couchbase/index.md
@@ -48,7 +48,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.Couchbase --version 3.9.0
+      dotnet add package Testcontainers.Couchbase
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/couchbase/

--- a/modules/couchdb/index.md
+++ b/modules/couchdb/index.md
@@ -14,7 +14,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.CouchDb --version 3.9.0
+      dotnet add package Testcontainers.CouchDb
       ```
 description: |
   CouchDB is an open-source document-oriented NoSQL clustered database that allows you to run a single logical database server on any number of servers or VM.

--- a/modules/dynamodb/index.md
+++ b/modules/dynamodb/index.md
@@ -26,7 +26,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.DynamoDb --version 3.9.0
+      dotnet add package Testcontainers.DynamoDb
       ```
 description: |
   Amazon DynamoDB is a fully managed NoSQL database service that provides fast and predictable performance with seamless scalability.

--- a/modules/elasticsearch/index.md
+++ b/modules/elasticsearch/index.md
@@ -44,7 +44,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.Elasticsearch --version 3.9.0
+      dotnet add package Testcontainers.Elasticsearch
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/elasticsearch/

--- a/modules/eventstoredb/index.md
+++ b/modules/eventstoredb/index.md
@@ -15,7 +15,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.EventStoreDb --version 3.9.0
+      dotnet add package Testcontainers.EventStoreDb
       ```
 description: |
   EventStoreDB is an event sourcing database that stores data in streams of immutable events.

--- a/modules/fake-gcs-server/index.md
+++ b/modules/fake-gcs-server/index.md
@@ -19,6 +19,20 @@ docs:
           <version>0.1.0</version>
       </dependency>
       ```
+  - id: dotnet
+    url: https://www.nuget.org/packages/Testcontainers.FakeGcsServer
+    maintainer: core
+    example: |
+      ```csharp
+      var fakeGcsServerContainer = new FakeGcsServerBuilder()
+        .WithImage("fsouza/fake-gcs-server:1.47")
+        .Build();
+      await fakeGcsServerContainer.StartAsync();
+      ```
+    installation: |
+      ```bash
+      dotnet add package Testcontainers.FakeGcsServer
+      ```
 description: |
   fake-gcs-server provides an emulator for Google Cloud Storage API.
 ---

--- a/modules/influxdb/index.md
+++ b/modules/influxdb/index.md
@@ -31,6 +31,20 @@ docs:
       ```bash
       go get github.com/testcontainers/testcontainers-go/modules/influxdb
       ```
+  - id: dotnet
+    url: https://www.nuget.org/packages/Testcontainers.InfluxDb
+    maintainer: core
+    example: |
+      ```csharp
+      var influxDbContainer = new InfluxDbBuilder()
+        .WithImage("influxdb:2.7")
+        .Build();
+      await influxDbContainer.StartAsync();
+      ```
+    installation: |
+      ```bash
+      dotnet add package Testcontainers.InfluxDb
+      ```
   - id: python
     url: https://testcontainers-python.readthedocs.io/en/latest/modules/influxdb/README.html
     maintainer: core

--- a/modules/k3s/index.md
+++ b/modules/k3s/index.md
@@ -43,7 +43,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.K3s --version 3.9.0
+      dotnet add package Testcontainers.K3s
       ```
   - id: python
     url: https://testcontainers-python.readthedocs.io/en/latest/modules/k3s/README.html

--- a/modules/kafka/index.md
+++ b/modules/kafka/index.md
@@ -43,7 +43,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.Kafka --version 3.9.0
+      dotnet add package Testcontainers.Kafka
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/kafka/

--- a/modules/keycloak/index.md
+++ b/modules/keycloak/index.md
@@ -50,7 +50,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.Keycloak --version 3.9.0
+      dotnet add package Testcontainers.Keycloak
       ```
   - id: python
     url: https://testcontainers-python.readthedocs.io/en/latest/modules/keycloak/README.html

--- a/modules/localstack/index.md
+++ b/modules/localstack/index.md
@@ -46,7 +46,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.LocalStack --version 3.9.0
+      dotnet add package Testcontainers.LocalStack
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/localstack/

--- a/modules/mariadb/index.md
+++ b/modules/mariadb/index.md
@@ -43,7 +43,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.MariaDb --version 3.9.0
+      dotnet add package Testcontainers.MariaDb
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/mariadb/

--- a/modules/microcks/index.md
+++ b/modules/microcks/index.md
@@ -55,7 +55,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Microcks.Testcontainers --version 0.1.0
+      dotnet add package Microcks.Testcontainers
       ``
 description: |
   Microcks is an open-source cloud-native platform for mocking and contract-testing all kinds of APIs. It supports REST [OpenAPI](https://www.openapis.org/), [gRPC](https://grpc.io/), [GraphQL](https://graphql.org/), [Async APIs](https://www.asyncapi.com/) and SOAP WebServices.

--- a/modules/milvus/index.md
+++ b/modules/milvus/index.md
@@ -42,7 +42,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.Milvus --version 3.9.0
+      dotnet add package Testcontainers.Milvus
       ```
   - id: python
     url: https://testcontainers-python.readthedocs.io/en/latest/modules/milvus/README.html

--- a/modules/minio/index.md
+++ b/modules/minio/index.md
@@ -43,7 +43,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.Minio --version 3.9.0
+      dotnet add package Testcontainers.Minio
       ```
   - id: python
     url: https://testcontainers-python.readthedocs.io/en/latest/modules/minio/README.html

--- a/modules/mongodb/index.md
+++ b/modules/mongodb/index.md
@@ -43,7 +43,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.MongoDb --version 3.9.0
+      dotnet add package Testcontainers.MongoDb
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/mongodb/

--- a/modules/mssql/index.md
+++ b/modules/mssql/index.md
@@ -47,7 +47,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.MsSql --version 3.9.0
+      dotnet add package Testcontainers.MsSql
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/mssqlserver/

--- a/modules/mysql/index.md
+++ b/modules/mysql/index.md
@@ -43,7 +43,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.MySql --version 3.9.0
+      dotnet add package Testcontainers.MySql
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/mysql/

--- a/modules/nats/index.md
+++ b/modules/nats/index.md
@@ -14,6 +14,20 @@ docs:
       ```bash
       go get github.com/testcontainers/testcontainers-go/modules/nats
       ```
+  - id: dotnet
+    url: https://www.nuget.org/packages/Testcontainers.Nats
+    maintainer: core
+    example: |
+      ```csharp
+      var natsContainer = new NatsBuilder()
+        .WithImage("nats:2.9")
+        .Build();
+      await natsContainer.StartAsync();
+      ```
+    installation: |
+      ```bash
+      dotnet add package Testcontainers.Nats
+      ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/nats/
     maintainer: core

--- a/modules/neo4j/index.md
+++ b/modules/neo4j/index.md
@@ -51,7 +51,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.Neo4j --version 3.9.0
+      dotnet add package Testcontainers.Neo4j
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/neo4j/

--- a/modules/oracle-xe/index.md
+++ b/modules/oracle-xe/index.md
@@ -32,7 +32,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.Oracle --version 3.9.0
+      dotnet add package Testcontainers.Oracle
       ```
 description: |
   Oracle Database Express Edition is a free, smaller-footprint edition of Oracle Database.

--- a/modules/pgvector/index.md
+++ b/modules/pgvector/index.md
@@ -50,7 +50,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.PostgreSql --version 3.9.0
+      dotnet add package Testcontainers.PostgreSql
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/postgresql/

--- a/modules/postgis/index.md
+++ b/modules/postgis/index.md
@@ -50,7 +50,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.PostgreSql --version 3.9.0
+      dotnet add package Testcontainers.PostgreSql
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/postgresql/

--- a/modules/postgresql/index.md
+++ b/modules/postgresql/index.md
@@ -49,7 +49,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.PostgreSql --version 3.9.0
+      dotnet add package Testcontainers.PostgreSql
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/postgresql/

--- a/modules/pulsar/index.md
+++ b/modules/pulsar/index.md
@@ -51,7 +51,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.Pulsar --version 3.9.0
+      dotnet add package Testcontainers.Pulsar
       ```
 description: |
   Apache Pulsar is an open-source, distributed messaging and streaming platform. Messages can be consumed and acknowledged individually or consumed as streams with less than 5ms of latency.

--- a/modules/rabbitmq/index.md
+++ b/modules/rabbitmq/index.md
@@ -43,7 +43,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.RabbitMq --version 3.9.0
+      dotnet add package Testcontainers.RabbitMq
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/rabbitmq/

--- a/modules/ravendb/index.md
+++ b/modules/ravendb/index.md
@@ -15,7 +15,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.RavenDb --version 3.9.0
+      dotnet add package Testcontainers.RavenDb
       ```
 description: |
   RavenDB is an open-source NoSQL database software designed to help businesses streamline multi-document ACID transactions and facilitate extract, transform, and load (ETL) operations.

--- a/modules/redis/index.md
+++ b/modules/redis/index.md
@@ -44,7 +44,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.Redis --version 3.9.0
+      dotnet add package Testcontainers.Redis
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/redis/

--- a/modules/redpanda/index.md
+++ b/modules/redpanda/index.md
@@ -46,7 +46,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.Redpanda --version 3.9.0
+      dotnet add package Testcontainers.Redpanda
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/redpanda/

--- a/modules/selenium/index.md
+++ b/modules/selenium/index.md
@@ -33,7 +33,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.WebDriver --version 3.9.0
+      dotnet add package Testcontainers.WebDriver
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/selenium/

--- a/modules/sqledge/index.md
+++ b/modules/sqledge/index.md
@@ -15,7 +15,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.SqlEdge --version 3.9.0
+      dotnet add package Testcontainers.SqlEdge
       ```
 description: |
   Azure SQL Edge is an Internet of Things (IoT) database for edge computing which combines capabilities such as data streaming and time series with built-in machine learning and graph features.

--- a/modules/timescale/index.md
+++ b/modules/timescale/index.md
@@ -50,7 +50,7 @@ docs:
       ```
     installation: |
       ```bash
-      dotnet add package Testcontainers.PostgreSql --version 3.9.0
+      dotnet add package Testcontainers.PostgreSql
       ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/postgresql/


### PR DESCRIPTION
The PR adds the following missing .NET modules to the Community Module Registry:

- ClickHouse
- CockroachDb
- Consul
- FakeGcsServer
- InfluxDb
- Nats

I also removed the `--version` option from the installation command. I believe it's unnecessary since the CLI will automatically install the latest available version, which is probably what we want anyway.

There are still a few modules left that I don't think exist in any other language. I created an issue in the Testcontainers for .NET repository, maybe someone from the community will pick it up. If not, I can take care of it from time to time: https://github.com/testcontainers/testcontainers-dotnet/issues/1372.