### PR TITLE
feat: Add missing .NET modules

### DIFF
--- a/modules/azure-eventhubs/index.md
+++ b/modules/azure-eventhubs/index.md
@@ -28,6 +28,20 @@ docs:
           <scope>test</scope>
       </dependency>
       ```
+  - id: dotnet
+    url: https://www.nuget.org/packages/Testcontainers.EventHubs
+    maintainer: core
+    example: |
+      ```csharp
+      var eventHubsContainer = new EventHubsBuilder()
+        .WithImage("mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest")
+        .Build();
+      await eventHubsContainer.StartAsync();
+      ```
+    installation: |
+      ```bash
+      dotnet add package Testcontainers.EventHubs
+      ```
 description: |
   Azure Event Hubs emulator is designed to offer a local development experience for Azure Event Hubs.
 ---

--- a/modules/azure-servicebus/index.md
+++ b/modules/azure-servicebus/index.md
@@ -31,6 +31,20 @@ docs:
           <scope>test</scope>
       </dependency>
       ```
+  - id: dotnet
+    url: https://www.nuget.org/packages/Testcontainers.ServiceBus
+    maintainer: core
+    example: |
+      ```csharp
+      var serviceBusContainer = new ServiceBusBuilder()
+        .WithImage("mcr.microsoft.com/azure-messaging/servicebus-emulator:latest")
+        .Build();
+      await serviceBusContainer.StartAsync();
+      ```
+    installation: |
+      ```bash
+      dotnet add package Testcontainers.ServiceBus
+      ```
 description: |
   The Azure Service Bus emulator offers a local development experience for the Service bus service.
 ---

--- a/modules/cassandra/index.md
+++ b/modules/cassandra/index.md
@@ -31,6 +31,20 @@ docs:
       ```bash
       go get github.com/testcontainers/testcontainers-go/modules/cassandra
       ```
+  - id: dotnet
+    url: https://www.nuget.org/packages/Testcontainers.Cassandra
+    maintainer: core
+    example: |
+      ```csharp
+      var cassandraContainer = new CassandraBuilder()
+        .WithImage("cassandra:5.0")
+        .Build();
+      await cassandraContainer.StartAsync();
+      ```
+    installation: |
+      ```bash
+      dotnet add package Testcontainers.Cassandra
+      ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/cassandra/
     maintainer: core

--- a/modules/db2/index.md
+++ b/modules/db2/index.md
@@ -21,6 +21,20 @@ docs:
           <scope>test</scope>
       </dependency>
       ```
+  - id: dotnet
+    url: https://www.nuget.org/packages/Testcontainers.Db2
+    maintainer: core
+    example: |
+      ```csharp
+      var db2Container = new Db2Builder()
+        .WithImage("icr.io/db2_community/db2:12.1.0.0")
+        .Build();
+      await db2Container.StartAsync();
+      ```
+    installation: |
+      ```bash
+      dotnet add package Testcontainers.Db2
+      ```
   - id: python
     url: https://testcontainers-python.readthedocs.io/en/latest/modules/db2/README.html
     maintainer: core


### PR DESCRIPTION
The PR adds the following missing .NET modules to the Community Module Registry for release 4.3.0:

- Cassandra
- Db2
- EventHubs
- ServiceBus