### PR TITLE
Provide images for all NodeJS modules

### DIFF
--- a/modules/arangodb/index.md
+++ b/modules/arangodb/index.md
@@ -39,7 +39,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new ArangoDBContainer().start();
+      const container = await new ArangoDBContainer("arangodb:3.10.0").start();
       ```
     installation: |
       ```bash

--- a/modules/chroma/index.md
+++ b/modules/chroma/index.md
@@ -35,7 +35,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new ChromaDBContainer().start();
+      const container = await new ChromaDBContainer("chromadb/chroma:0.6.3").start();
       ```
     installation: |
       ```bash

--- a/modules/cosmodb/index.md
+++ b/modules/cosmodb/index.md
@@ -36,6 +36,19 @@ docs:
       ```bash
       dotnet add package Testcontainers.CosmosDb
       ```
+  - id: nodejs
+    url: https://node.testcontainers.org/modules/cosmosdb/
+    maintainer: core
+    example: |
+      ```javascript
+      const container = await new AzureCosmosDbEmulatorContainer(
+        "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-EN20250228"
+      ).start();
+      ```
+    installation: |
+      ```bash
+      npm install @testcontainers/azure-cosmosdb-emulator --save-dev
+      ```
   - id: python
     url: https://testcontainers-python.readthedocs.io/en/latest/modules/cosmosdb/README.html
     maintainer: core

--- a/modules/couchbase/index.md
+++ b/modules/couchbase/index.md
@@ -55,7 +55,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new CouchbaseContainer().start();
+      const container = await new CouchbaseContainer("couchbase/server:community-7.0.2").start();
       ```
     installation: |
       ```bash

--- a/modules/elasticsearch/index.md
+++ b/modules/elasticsearch/index.md
@@ -51,7 +51,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new ElasticsearchContainer().start();
+      const container = await new ElasticsearchContainer("elasticsearch:7.17.7").start();
       ```
     installation: |
       ```bash

--- a/modules/google-cloud/index.md
+++ b/modules/google-cloud/index.md
@@ -42,7 +42,9 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const datastoreEmulatorContainer = await new DatastoreEmulatorContainer().start();
+      const datastoreEmulatorContainer = await new DatastoreEmulatorContainer(
+        "gcr.io/google.com/cloudsdktool/cloud-sdk"
+      ).start();
       ```
     installation: |
       ```bash

--- a/modules/hivemq/index.md
+++ b/modules/hivemq/index.md
@@ -26,7 +26,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new HiveMQContainer().start();
+      const container = await new HiveMQContainer("hivemq/hivemq-ce:2023.5").start();
       ```
     installation: |
       ```bash

--- a/modules/kafka/index.md
+++ b/modules/kafka/index.md
@@ -50,7 +50,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const kafkaContainer = await new KafkaContainer().withExposedPorts(9093).start();
+      const kafkaContainer = await new KafkaContainer("confluentinc/cp-kafka:7.2.2").start();
       ```
     installation: |
       ```bash

--- a/modules/localstack/index.md
+++ b/modules/localstack/index.md
@@ -53,7 +53,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new LocalstackContainer().start();
+      const container = await new LocalstackContainer("localstack/localstack:2.2.0").start();
       ```
     installation: |
       ```bash

--- a/modules/mariadb/index.md
+++ b/modules/mariadb/index.md
@@ -50,7 +50,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new MariaDbContainer().start();
+      const container = await new MariaDbContainer("mariadb:11.5.2").start();
       ```
     installation: |
       ```bash

--- a/modules/mongodb/index.md
+++ b/modules/mongodb/index.md
@@ -50,7 +50,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const mongodbContainer = await new MongoDBContainer().start();
+      const mongodbContainer = await new MongoDBContainer("mongo:6.0.1").start();
       ```
     installation: |
       ```bash

--- a/modules/mssql/index.md
+++ b/modules/mssql/index.md
@@ -54,7 +54,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new MSSQLServerContainer().start();
+      const container = await new MSSQLServerContainer("mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04").start();
       ```
     installation: |
       ```bash

--- a/modules/mysql/index.md
+++ b/modules/mysql/index.md
@@ -50,7 +50,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new MySqlContainer().start();
+      const container = await new MySqlContainer("mysql:8.0.31").start();
       ```
     installation: |
       ```bash

--- a/modules/nats/index.md
+++ b/modules/nats/index.md
@@ -33,7 +33,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new NatsContainer().start();
+      const container = await new NatsContainer("nats:2.8.4-alpine").start();
       ```
     installation: |
       ```bash

--- a/modules/neo4j/index.md
+++ b/modules/neo4j/index.md
@@ -58,7 +58,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new Neo4jContainer().start();
+      const container = await new Neo4jContainer("neo4j:4.4.12").start();
       ```
     installation: |
       ```bash

--- a/modules/ollama/index.md
+++ b/modules/ollama/index.md
@@ -41,7 +41,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new OllamaContainer().start();
+      const container = await new OllamaContainer("ollama/ollama:0.1.44").start();
       ```
     installation: |
       ```bash

--- a/modules/pgvector/index.md
+++ b/modules/pgvector/index.md
@@ -57,7 +57,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new PostgreSqlContainer(image="pgvector/pgvector:pg16").start();
+      const container = await new PostgreSqlContainer("pgvector/pgvector:pg16").start();
       ```
     installation: |
       ```bash

--- a/modules/postgis/index.md
+++ b/modules/postgis/index.md
@@ -57,7 +57,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new PostgreSqlContainer(image = "postgis/postgis:12-3.0").start();
+      const container = await new PostgreSqlContainer("postgis/postgis:12-3.0").start();
       ```
     installation: |
       ```bash

--- a/modules/postgresql/index.md
+++ b/modules/postgresql/index.md
@@ -56,7 +56,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new PostgreSqlContainer().start();
+      const container = await new PostgreSqlContainer("postgres:13.3-alpine").start();
       ```
     installation: |
       ```bash

--- a/modules/qdrant/index.md
+++ b/modules/qdrant/index.md
@@ -38,7 +38,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new QdrantContainer().start();
+      const container = await new QdrantContainer("qdrant/qdrant:v1.13.4").start();
       ```
     installation: |
       ```bash

--- a/modules/rabbitmq/index.md
+++ b/modules/rabbitmq/index.md
@@ -50,7 +50,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new RabbitMQContainer().start();
+      const container = await new RabbitMQContainer("rabbitmq:3.12.11-management-alpine").start();
       ```
     installation: |
       ```bash

--- a/modules/redis/index.md
+++ b/modules/redis/index.md
@@ -51,7 +51,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new RedisContainer().start();
+      const container = await new RedisContainer("redis:7.2").start();
       ```
     installation: |
       ```bash

--- a/modules/redpanda/index.md
+++ b/modules/redpanda/index.md
@@ -53,7 +53,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const redpandaContainer = await new RedpandaContainer().start();
+      const redpandaContainer = await new RedpandaContainer("docker.redpanda.com/redpandadata/redpanda:v23.3.10").start();
       ```
     installation: |
       ```bash

--- a/modules/timescale/index.md
+++ b/modules/timescale/index.md
@@ -57,7 +57,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new PostgreSqlContainer(image = "timescale/timescaledb:2.1.0-pg11").start();
+      const container = await new PostgreSqlContainer("timescale/timescaledb:2.1.0-pg11").start();
       ```
     installation: |
       ```bash

--- a/modules/weaviate/index.md
+++ b/modules/weaviate/index.md
@@ -52,7 +52,7 @@ docs:
     maintainer: core
     example: |
       ```javascript
-      const container = await new WeaviateContainer().start();
+      const container = await new WeaviateContainer("semitechnologies/weaviate:1.24.5").start();
       ```
     installation: |
       ```bash


### PR DESCRIPTION
In preparation for testcontainers-node release [11.0.0](https://github.com/testcontainers/testcontainers-node/pull/938), module images will no longer be defaulted and must be specified explicitly. This PR updates the docs to reflect this.