### PR TITLE
azure-servicebus - update dotnet docs to use mssql container

### DIFF
--- a/modules/azure-servicebus/index.md
+++ b/modules/azure-servicebus/index.md
@@ -36,9 +36,19 @@ docs:
     maintainer: core
     example: |
       ```csharp
+      var network = new NetworkBuilder().Build();
+      var mssql = new MsSqlBuilder()
+          .WithImage("mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04")
+          .WithNetwork(network)
+          .WithNetworkAliases(ServiceBusBuilder.DatabaseNetworkAlias)
+          .Build();
+      await mssql.StartAsync();
+
       var serviceBusContainer = new ServiceBusBuilder()
-        .WithImage("mcr.microsoft.com/azure-messaging/servicebus-emulator:latest")
-        .Build();
+          .WithImage("mcr.microsoft.com/azure-messaging/servicebus-emulator:1.0.1")
+          .WithAcceptLicenseAgreement(true)
+          .WithMsSqlContainer(network, mssql, ServiceBusBuilder.DatabaseNetworkAlias)
+          .Build();
       await serviceBusContainer.StartAsync();
       ```
     installation: |


### PR DESCRIPTION
tested locally with the sample console application

```cs
using DotNet.Testcontainers.Builders;
using DotNet.Testcontainers.Containers;
using DotNet.Testcontainers.Networks;
using Testcontainers.MsSql;
using Testcontainers.ServiceBus;

var network = new NetworkBuilder().Build();

var mssql = new MsSqlBuilder()
    .WithImage("mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04")
    .WithNetwork(network)
    .WithNetworkAliases(ServiceBusBuilder.DatabaseNetworkAlias)
    .Build();

await mssql.StartAsync();

var serviceBusContainer = new ServiceBusBuilder()
    .WithImage("mcr.microsoft.com/azure-messaging/servicebus-emulator:latest")
    .WithAcceptLicenseAgreement(true)
    .WithMsSqlContainer(network, mssql, ServiceBusBuilder.DatabaseNetworkAlias)
    .Build();

await serviceBusContainer.StartAsync();

await Task.Delay(TimeSpan.FromSeconds(10));

await serviceBusContainer.StopAsync();
await mssql.StopAsync();
```

and the csproj
```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>net9.0</TargetFramework>
    <RootNamespace>testcontainers_dotnet_demo</RootNamespace>
    <LangVersion>latest</LangVersion>
    <OutputType>Exe</OutputType>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="Testcontainers.ServiceBus" Version="4.3.0" />
  </ItemGroup>

</Project>
```