### PR TITLE
chore(dotnet): Add module description

### DIFF
--- a/modules/google-cloud/index.md
+++ b/modules/google-cloud/index.md
@@ -37,6 +37,25 @@ docs:
       ```bash
       go get github.com/testcontainers/testcontainers-go/modules/gcloud
       ```
+  - id: dotnet
+    url: https://www.nuget.org/packages/Testcontainers.GCloud
+    maintainer: core
+    example: |
+      ```csharp
+      // The GCloud module wraps multiple Google Cloud services, including BigQuery,
+      // Bigtable, Firestore (Datastore), and PubSub, into a single, unified dependency.
+      // The services follow the naming convention:
+      // FirestoreBuilder, FirestoreContainer, etc.
+
+      var firestoreContainer = new FirestoreBuilder()
+        .WithImage("gcr.io/google.com/cloudsdktool/google-cloud-cli:446.0.1-emulators")
+        .Build();
+      await firestoreContainer.StartAsync();
+      ```
+    installation: |
+      ```bash
+      dotnet add package Testcontainers.GCloud
+      ```
   - id: nodejs
     url: https://node.testcontainers.org/modules/gcloud/
     maintainer: core
@@ -61,23 +80,6 @@ docs:
     installation: |
       ```bash
       pip install testcontainers[google]
-      ```
-  - id: dotnet
-    url: https://www.nuget.org/packages/Testcontainers.GCloud
-    maintainer: core
-    example: |
-      ```csharp
-      var firestoreContainer = new FirestoreBuilder()
-        .WithImage("gcr.io/google.com/cloudsdktool/google-cloud-cli:446.0.1-emulators")
-        .Build();
-      await firestoreContainer.StartAsync();
-
-      // supported modules:
-      // BigQuery, Bigtable, Firestore (Datastore), PubSub
-      ```
-    installation: |
-      ```bash
-      dotnet add package Testcontainers.GCloud
       ```
 description: |
   Google's Cloud SDK provides a platform to work with the services provided through their Cloud Platform.

--- a/modules/xunit/index.md
+++ b/modules/xunit/index.md
@@ -8,14 +8,24 @@ docs:
     maintainer: core
     example: |
       ```csharp
+      // Inherit from either the `ContainerTest` or `ContainerFixture` class, set up your
+      // container instance in `Configure(TContainerBuilder)`, and access the running
+      // container in your test method using the `Container` property. The module handles
+      // creating, starting, and disposing of the container instances in the background.
+
       public sealed partial class RedisContainerTest(ITestOutputHelper testOutputHelper)
-          : ContainerTest<RedisBuilder, RedisContainer>(testOutputHelper)
+        : ContainerTest<RedisBuilder, RedisContainer>(testOutputHelper)
       {
-          protected override RedisBuilder Configure(RedisBuilder builder)
-          {
-              // 👇 Configure your container instance here.
-              return builder.WithImage("redis:7.0");
-          }
+        protected override RedisBuilder Configure(RedisBuilder builder)
+        {
+          return builder.WithImage("redis:7.0");
+        }
+
+        [Fact]
+        public async Task Test1()
+        {
+          _ = Container.GetConnectionString();
+        }
       }
       ```
     installation: |
@@ -25,5 +35,5 @@ docs:
 description: |
   The Testcontainers.Xunit package simplifies writing tests with containers in xUnit.net. By leveraging xUnit.net's shared context, this package automates the setup and teardown of test resources, creating and disposing of containers as needed. This reduces repetitive code and avoids common patterns that developers would otherwise need to implement repeatedly.
 
-  You can read full example and docs here: https://dotnet.testcontainers.org/test_frameworks/xunit_net/
+  You can read full example and docs here: https://dotnet.testcontainers.org/test_frameworks/xunit_net/.
 ---


### PR DESCRIPTION
This PR adds a bit more information to the GCloud and xUnit.net modules, since they're a little different from the other ones. The comments should help developers understand how to use and adapt these modules properly.