### PR TITLE
Add new java module for Floci

### DIFF
--- a/modules/floci/index.md
+++ b/modules/floci/index.md
@@ -2,9 +2,6 @@
 title: Floci
 categories:
   - cloud
-officialPartner:
-  name: Floci
-  url: https://floci.io/
 docs:
   - id: java
     url: https://github.com/floci-io/testcontainers-floci

--- a/modules/floci/index.md
+++ b/modules/floci/index.md
@@ -1,0 +1,28 @@
+---
+title: Floci
+categories:
+  - cloud
+officialPartner:
+  name: Floci
+  url: https://floci.io/
+docs:
+  - id: java
+    url: https://github.com/floci-io/testcontainers-floci
+    maintainer: official
+    example: |
+      ```java
+      var floci = new FlociContainer();
+      floci.start();
+      ```
+    installation: |
+      ```xml
+      <dependency>
+          <groupId>io.floci</groupId>
+          <artifactId>testcontainers-floci</artifactId>
+          <version>2.0.0</version>
+          <scope>test</scope>
+      </dependency>
+      ```
+description: |
+  Floci is a fast, free, open-source AWS emulator built with Quarkus Native. Starts in 24ms, uses 13 MiB at idle. Drop-in replacement for LocalStack — no auth token, no restrictions, ever.
+---

--- a/modules/floci/logo.svg
+++ b/modules/floci/logo.svg
@@ -1,0 +1,28 @@
+<svg viewBox="70 58 274 172" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="pm-l" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fff8e1"/>
+      <stop offset="100%" stop-color="#ffe082"/>
+    </linearGradient>
+    <linearGradient id="ps-l" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffe082"/>
+      <stop offset="100%" stop-color="#e6ac00"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Popcorn cloud -->
+  <g transform="translate(200,168)">
+    <rect x="-108" y="-20" width="216" height="60" rx="30" fill="url(#ps-l)"/>
+    <circle cx="-74" cy="-20" r="40" fill="url(#ps-l)"/>
+    <circle cx="-22" cy="-44" r="52" fill="url(#pm-l)"/>
+    <circle cx="36" cy="-36" r="46" fill="url(#pm-l)"/>
+    <circle cx="86" cy="-18" r="34" fill="url(#ps-l)"/>
+    <ellipse cx="8" cy="-30" rx="72" ry="28" fill="#fff8e1" opacity="0.55"/>
+    <circle cx="-58" cy="-34" r="7" fill="#fff8e1" opacity="0.75"/>
+    <circle cx="-12" cy="-60" r="8.5" fill="#fff8e1" opacity="0.70"/>
+    <circle cx="38" cy="-54" r="7.5" fill="#fff8e1" opacity="0.70"/>
+    <circle cx="82" cy="-28" r="6" fill="#fff8e1" opacity="0.65"/>
+    <!-- Shadow -->
+    <ellipse cx="4" cy="42" rx="90" ry="9" fill="#c4a000" opacity="0.12"/>
+  </g>
+</svg>


### PR DESCRIPTION
This PR adds a Java module for Floci - an AWS emulator (https://floci.io/)